### PR TITLE
Fix up several minor code quality problems that trigger clang warnings

### DIFF
--- a/src/libmowgli/base/argstack.c
+++ b/src/libmowgli/base/argstack.c
@@ -108,7 +108,6 @@ mowgli_argstack_create_from_va_list(const char *descstr, va_list va)
 			mowgli_object_unref(out);
 			mowgli_log_warning("invalid description");
 			return NULL;
-			break;
 		}
 
 		mowgli_node_add(e, mowgli_node_create(), &out->stack);

--- a/src/libmowgli/base/formatter.c
+++ b/src/libmowgli/base/formatter.c
@@ -86,7 +86,7 @@ mowgli_formatter_format_from_argstack(char *buf, size_t bufstr, const char *fmts
 			}
 
 			continue;
-			break;
+
 		default:
 			*i = *fiter;
 		}

--- a/src/libmowgli/core/process.c
+++ b/src/libmowgli/core/process.c
@@ -61,23 +61,16 @@ mowgli_process_clone(mowgli_process_start_fn_t start_fn, const char *procname, v
 
 	switch (out->pid)
 	{
-	default:
-		break;
-
 	case 0:
-
 		/* Do our best to set this... */
 		mowgli_proctitle_set("%s", procname);
 		start_fn(out->userdata);
 		_exit(255);
-
 		return NULL;
-		break;
 
 	case -1:
 		mowgli_free(out);
 		return NULL;
-		break;
 	}
 
 	return out;

--- a/src/libmowgli/eventloop/select_pollops.c
+++ b/src/libmowgli/eventloop/select_pollops.c
@@ -134,7 +134,7 @@ mowgli_select_eventloop_select(mowgli_eventloop_t *eventloop, int delay)
 
 	MOWGLI_ITER_FOREACH_SAFE(n, tn, priv->pollable_list.head)
 	{
-		mowgli_eventloop_pollable_t *pollable = n->data;
+		pollable = n->data;
 
 # ifdef DEBUG
 		mowgli_log("considering fd %d pollable %p count %d", pollable->fd, pollable, priv->pollable_list.count);

--- a/src/libmowgli/ext/error_backtrace.h
+++ b/src/libmowgli/ext/error_backtrace.h
@@ -30,7 +30,7 @@ typedef struct mowgli_error_context_
 } mowgli_error_context_t;
 
 extern void mowgli_error_context_display(mowgli_error_context_t *e, const char *delim);
-extern void mowgli_error_context_display_with_error(mowgli_error_context_t *e, const char *delim, const char *error);
+extern void mowgli_error_context_display_with_error(mowgli_error_context_t *e, const char *delim, const char *error) __attribute__((noreturn));
 extern void mowgli_error_context_destroy(mowgli_error_context_t *e);
 extern void mowgli_error_context_push(mowgli_error_context_t *e, const char *msg, ...);
 extern void mowgli_error_context_pop(mowgli_error_context_t *e);

--- a/src/libmowgli/ext/json.c
+++ b/src/libmowgli/ext/json.c
@@ -1259,8 +1259,6 @@ lex_char(mowgli_json_parse_t *parse, char c)
 			return true;
 		}
 
-		break;
-
 	case LEX_IDENTIFIER:
 
 		if (isalpha((unsigned char)c))
@@ -1273,8 +1271,6 @@ lex_char(mowgli_json_parse_t *parse, char c)
 			lex_tokenize(parse);
 			return true;
 		}
-
-		break;
 	}
 
 	/* This should never happen... */

--- a/src/libmowgli/ext/program_opts.c
+++ b/src/libmowgli/ext/program_opts.c
@@ -105,17 +105,17 @@ mowgli_program_opts_compute_optstr(const mowgli_program_opts_t *opts, size_t opt
 }
 
 static inline void
-mowgli_program_opts_dispatch(const mowgli_program_opts_t *opt, const char *optarg)
+mowgli_program_opts_dispatch(const mowgli_program_opts_t *opt, const char *opt_arg)
 {
 	return_if_fail(opt != NULL);
 
-	if (opt->has_param && (optarg == NULL))
+	if (opt->has_param && (opt_arg == NULL))
 	{
 		fprintf(stderr, "no optarg for option %s", opt->longopt);
 		return;
 	}
 
-	opt->consumer(optarg, opt->userdata);
+	opt->consumer(opt_arg, opt->userdata);
 }
 
 void

--- a/src/libmowgli/vio/vio_sockets.c
+++ b/src/libmowgli/vio/vio_sockets.c
@@ -476,15 +476,15 @@ mowgli_vio_sockaddr_info(const mowgli_vio_sockaddr_t *addr, mowgli_vio_sockdata_
 
 	if (saddr->sa_family == AF_INET)
 	{
-		const struct sockaddr_in *saddr = (const struct sockaddr_in *) &addr->addr;
-		data->port = ntohs(saddr->sin_port);
-		sockptr = &saddr->sin_addr;
+		const struct sockaddr_in *saddr4 = (const struct sockaddr_in *) &addr->addr;
+		data->port = ntohs(saddr4->sin_port);
+		sockptr = &saddr4->sin_addr;
 	}
 	else if (saddr->sa_family == AF_INET6)
 	{
-		const struct sockaddr_in6 *saddr = (const struct sockaddr_in6 *) &addr->addr;
-		data->port = ntohs(saddr->sin6_port);
-		sockptr = &saddr->sin6_addr;
+		const struct sockaddr_in6 *saddr6 = (const struct sockaddr_in6 *) &addr->addr;
+		data->port = ntohs(saddr6->sin6_port);
+		sockptr = &saddr6->sin6_addr;
 	}
 	else
 	{


### PR DESCRIPTION
Includes break statements that will never be executed, functions that
should be marked noreturn, and shadowed variable declarations.